### PR TITLE
[Bug Fix] fix failover message ordering bug

### DIFF
--- a/core/manage/client.go
+++ b/core/manage/client.go
@@ -61,9 +61,7 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 	}
 
 	handler := func(f frame.Frame) {
-		// All message types can be handled in
-		// parallel, since their ordering should not matter
-		go c.handleFrame(f)
+		c.handleFrame(f)
 	}
 
 	go func() {


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>


### Motivation

In the `handlerMessage`, each frame will start a `gorutine` to execute, resulting in the status of the unscheduled message in the failover subscription mode.