### PR TITLE
Support different authentication methods

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -15,7 +15,7 @@ Usage of ./cli:
   -producer
     	if true, produce messages, otherwise consume
   -pulsar string
-    	pulsar address (default "localhost:6650")
+    	pulsar address. May start with pulsar:// or pulsar+ssl:// (default "localhost:6650")
   -rate duration
     	rate at which to send messages (default 1s)
   -shared

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -131,16 +131,18 @@ func main() {
 	switch args.producer {
 	case true:
 		// Create the managed producer
-		mpCfg := manage.ProducerConfig{
+		mpCfg := manage.ManagedProducerConfig{
 			Name:                  args.name,
 			Topic:                 args.topic,
 			NewProducerTimeout:    time.Second,
 			InitialReconnectDelay: time.Second,
 			MaxReconnectDelay:     time.Minute,
-			ClientConfig: manage.ClientConfig{
-				Addr:      args.pulsar,
-				TLSConfig: tlsCfg,
-				Errs:      asyncErrs,
+			ManagedClientConfig: manage.ManagedClientConfig{
+				ClientConfig: manage.ClientConfig{
+					Addr:      args.pulsar,
+					TLSConfig: tlsCfg,
+					Errs:      asyncErrs,
+				},
 			},
 		}
 		mp := manage.NewManagedProducer(mcp, mpCfg)
@@ -183,7 +185,7 @@ func main() {
 					return
 				}
 				sctx, cancel := context.WithTimeout(ctx, time.Second)
-				_, err := mp.Send(sctx, payload,"")
+				_, err := mp.Send(sctx, payload, "")
 				cancel()
 				if err != nil {
 					fmt.Fprintln(os.Stderr, err)
@@ -199,16 +201,18 @@ func main() {
 		queue := make(chan msg.Message, 8)
 
 		// Create managed consumer
-		mcCfg := manage.ConsumerConfig{
+		mcCfg := manage.ManagedConsumerConfig{
 			Name:                  args.name,
 			Topic:                 args.topic,
 			NewConsumerTimeout:    time.Second,
 			InitialReconnectDelay: time.Second,
 			MaxReconnectDelay:     time.Minute,
-			ClientConfig: manage.ClientConfig{
-				Addr:      args.pulsar,
-				TLSConfig: tlsCfg,
-				Errs:      asyncErrs,
+			ManagedClientConfig: manage.ManagedClientConfig{
+				ClientConfig: manage.ClientConfig{
+					Addr:      args.pulsar,
+					TLSConfig: tlsCfg,
+					Errs:      asyncErrs,
+				},
 			},
 		}
 

--- a/core/auth/basic.go
+++ b/core/auth/basic.go
@@ -1,0 +1,48 @@
+package auth
+
+import (
+	"encoding/base64"
+	"net/http"
+)
+
+func NewAuthenticationBasic(userId, password string) Authentication {
+	return authenticationBasic{userId: userId, password: password}
+}
+
+type authenticationBasic struct {
+	userId, password string
+}
+
+func (a authenticationBasic) GetAuthMethodName() string {
+	return "basic"
+}
+func (a authenticationBasic) GetAuthData() AuthenticationDataProvider {
+	commandAuthToken := []byte(a.userId + ":" + a.password)
+	httpAuthToken := "Basic " + base64.StdEncoding.EncodeToString(commandAuthToken)
+	return authenticationDataBasic{
+		httpAuthToken:    httpAuthToken,
+		commandAuthToken: commandAuthToken,
+	}
+}
+
+type authenticationDataBasic struct {
+	authenticationDataNull
+	httpAuthToken    string
+	commandAuthToken []byte
+}
+
+func (adBasic authenticationDataBasic) HasDataForHttp() bool {
+	return true
+}
+func (adBasic authenticationDataBasic) GetHttpHeaders() http.Header {
+	return http.Header{
+		"Authorization": []string{adBasic.httpAuthToken},
+	}
+}
+
+func (adBasic authenticationDataBasic) HasDataFromCommand() bool {
+	return true
+}
+func (adBasic authenticationDataBasic) GetCommandData() []byte {
+	return adBasic.commandAuthToken
+}

--- a/core/auth/disabled.go
+++ b/core/auth/disabled.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	"crypto/tls"
+	"net/http"
+)
+
+func NewAuthenticationDisabled() Authentication {
+	return authenticationDisabled{}
+}
+
+type authenticationDisabled struct{}
+
+func (a authenticationDisabled) GetAuthMethodName() string {
+	return ""
+}
+func (a authenticationDisabled) GetAuthData() AuthenticationDataProvider {
+	return authenticationDataNull{}
+}
+
+type authenticationDataNull struct{}
+
+func (adNull authenticationDataNull) HasDataForTls() bool {
+	return false
+}
+func (adNull authenticationDataNull) GetTlsCertificates() []tls.Certificate {
+	return nil
+}
+
+func (adNull authenticationDataNull) HasDataForHttp() bool {
+	return false
+}
+func (adNull authenticationDataNull) GetHttpAuthType() string {
+	return ""
+}
+func (adNull authenticationDataNull) GetHttpHeaders() http.Header {
+	return nil
+}
+
+func (adNull authenticationDataNull) HasDataFromCommand() bool {
+	return false
+}
+func (adNull authenticationDataNull) GetCommandData() []byte {
+	return nil
+}

--- a/core/auth/interface.go
+++ b/core/auth/interface.go
@@ -1,0 +1,26 @@
+package auth
+
+import (
+	"crypto/tls"
+	"net/http"
+)
+
+type (
+	Authentication interface {
+		GetAuthMethodName() string
+		GetAuthData() AuthenticationDataProvider
+	}
+
+	AuthenticationDataProvider interface {
+		HasDataForTls() bool
+		GetTlsCertificates() []tls.Certificate
+		// GetTslPrivateKey is redundant due to Go TLS implementation
+
+		HasDataForHttp() bool
+		GetHttpAuthType() string
+		GetHttpHeaders() http.Header
+
+		HasDataFromCommand() bool
+		GetCommandData() []byte
+	}
+)

--- a/core/auth/tls.go
+++ b/core/auth/tls.go
@@ -1,0 +1,34 @@
+package auth
+
+import "crypto/tls"
+
+func NewAuthenticationTLS(certFile, keyFile string) Authentication {
+	return authenticationTls{certFile: certFile, keyFile: keyFile}
+}
+
+type authenticationTls struct {
+	certFile, keyFile string
+}
+
+func (a authenticationTls) GetAuthMethodName() string {
+	return "tls"
+}
+func (a authenticationTls) GetAuthData() AuthenticationDataProvider {
+	if certificate, err := tls.LoadX509KeyPair(a.certFile, a.keyFile); err == nil {
+		return authenticationDataTls{certificates: []tls.Certificate{certificate}}
+	} else {
+		panic(err)
+	}
+}
+
+type authenticationDataTls struct {
+	authenticationDataNull
+	certificates []tls.Certificate
+}
+
+func (adTls authenticationDataTls) HasDataForTls() bool {
+	return true
+}
+func (adTls authenticationDataTls) GetTlsCertificates() []tls.Certificate {
+	return adTls.certificates
+}

--- a/core/auth/token.go
+++ b/core/auth/token.go
@@ -1,0 +1,61 @@
+package auth
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+type AuthenticationTokenSupplier func() []byte
+
+func NewAuthenticationTokenFromSupplier(tokenSupplier AuthenticationTokenSupplier) Authentication {
+	return authenticationToken{supplier: tokenSupplier}
+}
+func NewAuthenticationTokenFromString(token string) Authentication {
+	token = strings.TrimPrefix(token, "token:")
+	return authenticationToken{supplier: func() []byte {
+		return []byte(token)
+	}}
+}
+func NewAuthenticationTokenFromFile(fileName string) Authentication {
+	fileName = strings.TrimPrefix(fileName, "file:")
+	return authenticationToken{supplier: func() []byte {
+		if content, err := ioutil.ReadFile(fileName); err == nil {
+			return content
+		} else {
+			panic(err)
+		}
+	}}
+}
+
+type authenticationToken struct {
+	supplier AuthenticationTokenSupplier
+}
+
+func (a authenticationToken) GetAuthMethodName() string {
+	return "token"
+}
+func (a authenticationToken) GetAuthData() AuthenticationDataProvider {
+	return authenticationDataToken{supplier: a.supplier}
+}
+
+type authenticationDataToken struct {
+	authenticationDataNull
+	supplier AuthenticationTokenSupplier
+}
+
+func (adToken authenticationDataToken) HasDataForHttp() bool {
+	return true
+}
+func (adToken authenticationDataToken) GetHttpHeaders() http.Header {
+	return http.Header{
+		"Authorization": []string{"Bearer " + string(adToken.supplier())},
+	}
+}
+
+func (adToken authenticationDataToken) HasDataFromCommand() bool {
+	return true
+}
+func (adToken authenticationDataToken) GetCommandData() []byte {
+	return adToken.supplier()
+}

--- a/core/conn/conn.go
+++ b/core/conn/conn.go
@@ -26,10 +26,15 @@ import (
 	"github.com/wolfstudy/pulsar-client-go/pkg/api"
 )
 
+const (
+	SchemaPulsar    = "pulsar://"
+	SchemaPulsarTSL = "pulsar+ssl://"
+)
+
 // NewTCPConn creates a core using a TCPv4 connection to the given
 // (pulsar server) address.
 func NewTCPConn(addr string, timeout time.Duration) (*Conn, error) {
-	addr = strings.TrimPrefix(addr, "pulsar://")
+	addr = strings.TrimPrefix(addr, SchemaPulsar)
 
 	d := net.Dialer{
 		DualStack: false,
@@ -50,7 +55,8 @@ func NewTCPConn(addr string, timeout time.Duration) (*Conn, error) {
 // NewTLSConn creates a core using a TCPv4+TLS connection to the given
 // (pulsar server) address.
 func NewTLSConn(addr string, tlsCfg *tls.Config, timeout time.Duration) (*Conn, error) {
-	addr = strings.TrimPrefix(addr, "pulsar://")
+	addr = strings.TrimPrefix(addr, SchemaPulsar)
+	addr = strings.TrimPrefix(addr, SchemaPulsarTSL)
 
 	d := net.Dialer{
 		DualStack: false,

--- a/core/conn/conn.go
+++ b/core/conn/conn.go
@@ -41,9 +41,9 @@ func NewTCPConn(addr string, timeout time.Duration) (*Conn, error) {
 	}
 
 	return &Conn{
-		Rc:      c,
-		W:       c,
-		Closedc: make(chan struct{}),
+		rc:      c,
+		w:       c,
+		closedc: make(chan struct{}),
 	}, nil
 }
 
@@ -62,23 +62,23 @@ func NewTLSConn(addr string, tlsCfg *tls.Config, timeout time.Duration) (*Conn, 
 	}
 
 	return &Conn{
-		Rc:      c,
-		W:       c,
-		Closedc: make(chan struct{}),
+		rc:      c,
+		w:       c,
+		closedc: make(chan struct{}),
 	}, nil
 }
 
 // Conn is responsible for writing and reading
 // Frames to and from the underlying connection (r and w).
 type Conn struct {
-	Rc io.ReadCloser
+	rc io.ReadCloser
 
-	Wmu sync.Mutex // protects w to ensure frames aren't interleaved
-	W   io.Writer
+	wmu sync.Mutex // protects w to ensure frames aren't interleaved
+	w   io.Writer
 
-	Cmu      sync.Mutex // protects following
-	IsClosed bool
-	Closedc  chan struct{}
+	cmu      sync.Mutex // protects following
+	isClosed bool
+	closedc  chan struct{}
 }
 
 // Close closes the underlaying connection.
@@ -86,16 +86,16 @@ type Conn struct {
 // an error. It will also cause the closed channel
 // to unblock.
 func (c *Conn) Close() error {
-	c.Cmu.Lock()
-	defer c.Cmu.Unlock()
+	c.cmu.Lock()
+	defer c.cmu.Unlock()
 
-	if c.IsClosed {
+	if c.isClosed {
 		return nil
 	}
 
-	err := c.Rc.Close()
-	close(c.Closedc)
-	c.IsClosed = true
+	err := c.rc.Close()
+	close(c.closedc)
+	c.isClosed = true
 
 	return err
 }
@@ -104,7 +104,7 @@ func (c *Conn) Close() error {
 // when the connection has been closed and is no
 // longer usable.
 func (c *Conn) Closed() <-chan struct{} {
-	return c.Closedc
+	return c.closedc
 }
 
 // Read blocks while it reads from r until an error occurs.
@@ -116,7 +116,7 @@ func (c *Conn) Closed() <-chan struct{} {
 func (c *Conn) Read(frameHandler func(f frame.Frame)) error {
 	for {
 		var f frame.Frame
-		if err := f.Decode(c.Rc); err != nil {
+		if err := f.Decode(c.rc); err != nil {
 			// It's very possible that the connection is already closed at this
 			// point, since any connection closed errors would bubble up
 			// from Decode. But just in case it's a decode error (bad data for example),
@@ -164,9 +164,9 @@ func (c *Conn) writeFrame(f *frame.Frame) error {
 		return err
 	}
 
-	c.Wmu.Lock()
-	_, err := b.WriteTo(c.W)
-	c.Wmu.Unlock()
+	c.wmu.Lock()
+	_, err := b.WriteTo(c.w)
+	c.wmu.Unlock()
 
 	return err
 }

--- a/core/conn/conn_test.go
+++ b/core/conn/conn_test.go
@@ -60,10 +60,10 @@ func TestConn_Read(t *testing.T) {
 	}
 
 	c := Conn{
-		Rc: &mockReadCloser{
+		rc: &mockReadCloser{
 			Reader: &b,
 		},
-		Closedc: make(chan struct{}),
+		closedc: make(chan struct{}),
 	}
 
 	var gotFrames []frame.Frame
@@ -87,10 +87,10 @@ func TestConn_Read(t *testing.T) {
 
 func TestConn_Close(t *testing.T) {
 	c := Conn{
-		Rc: &mockReadCloser{
+		rc: &mockReadCloser{
 			Reader: new(bytes.Buffer),
 		},
-		Closedc: make(chan struct{}),
+		closedc: make(chan struct{}),
 	}
 
 	// no-op
@@ -116,8 +116,8 @@ func TestConn_GarbageInput(t *testing.T) {
 		Reader: bytes.NewBufferString("this isn't a valid Pulsar frame"),
 	}
 	c := Conn{
-		Rc:      mrc,
-		Closedc: make(chan struct{}),
+		rc:      mrc,
+		closedc: make(chan struct{}),
 	}
 
 	var gotFrames []frame.Frame
@@ -164,8 +164,8 @@ func TestConn_TimeoutReader(t *testing.T) {
 		Reader: iotest.TimeoutReader(&b),
 	}
 	c := Conn{
-		Rc:      mrc,
-		Closedc: make(chan struct{}),
+		rc:      mrc,
+		closedc: make(chan struct{}),
 	}
 
 	var gotFrames []frame.Frame
@@ -205,10 +205,10 @@ func TestConn_Read_SlowSrc(t *testing.T) {
 	c := Conn{
 		// OneByteReader returns a single byte per read,
 		// regardless of how big its input buffer is.
-		Rc: &mockReadCloser{
+		rc: &mockReadCloser{
 			Reader: iotest.OneByteReader(&b),
 		},
-		Closedc: make(chan struct{}),
+		closedc: make(chan struct{}),
 	}
 
 	var gotFrames []frame.Frame
@@ -267,10 +267,10 @@ func TestConn_Read_MutliFrame(t *testing.T) {
 	}
 
 	c := Conn{
-		Rc: &mockReadCloser{
+		rc: &mockReadCloser{
 			Reader: &b,
 		},
-		Closedc: make(chan struct{}),
+		closedc: make(chan struct{}),
 	}
 
 	var gotFrames []frame.Frame
@@ -326,11 +326,11 @@ func TestConn_writeFrame(t *testing.T) {
 	// same buffer is used for reads and writes
 	var rw bytes.Buffer
 	c := Conn{
-		Rc: &mockReadCloser{
+		rc: &mockReadCloser{
 			Reader: &rw,
 		},
-		W:       &rw,
-		Closedc: make(chan struct{}),
+		w:       &rw,
+		closedc: make(chan struct{}),
 	}
 
 	// write the frames in parallel (order will

--- a/core/conn/connector.go
+++ b/core/conn/connector.go
@@ -63,7 +63,7 @@ type Connector struct {
 // The provided context should have a timeout associated with it.
 //
 // It's required to have completed Connect/Connected before using the client.
-func (c *Connector) Connect(ctx context.Context, authMethod, proxyBrokerURL string) (*api.CommandConnected, error) {
+func (c *Connector) Connect(ctx context.Context, authMethod string, authData []byte, proxyBrokerURL string) (*api.CommandConnected, error) {
 	resp, cancel, err := c.dispatcher.RegisterGlobal()
 	if err != nil {
 		return nil, err
@@ -88,6 +88,7 @@ func (c *Connector) Connect(ctx context.Context, authMethod, proxyBrokerURL stri
 	}
 	if authMethod != "" {
 		connect.AuthMethodName = proto.String(authMethod)
+		connect.AuthData = authData
 	}
 	if proxyBrokerURL != "" {
 		connect.ProxyToBrokerUrl = proto.String(proxyBrokerURL)

--- a/core/conn/connector.go
+++ b/core/conn/connector.go
@@ -20,14 +20,30 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/wolfstudy/pulsar-client-go/core/frame"
 	"github.com/wolfstudy/pulsar-client-go/pkg/api"
-	"github.com/wolfstudy/pulsar-client-go/utils"
+)
+
+const (
+	// ProtoVersion is the Pulsar protocol version
+	// used by this client.
+	ProtoVersion = int32(api.ProtocolVersion_v12)
+
+	// ClientVersion is an opaque string sent
+	// by the client to the server on connect, eg:
+	// "Pulsar-Client-Java-v1.15.2"
+	ClientVersion = "pulsar-client-go"
+
+	// undefRequestID defines a RequestID of -1.
+	//
+	// Usage example:
+	// https://github.com/apache/incubator-pulsar/blob/fdc7b8426d8253c9437777ae51a4639239550f00/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java#L325
+	undefRequestID = 1<<64 - 1
 )
 
 // NewConnector returns a ready-to-use connector.
 func NewConnector(s frame.CmdSender, dispatcher *frame.Dispatcher) *Connector {
 	return &Connector{
-		S:          s,
-		Dispatcher: dispatcher,
+		s:          s,
+		dispatcher: dispatcher,
 	}
 }
 
@@ -36,8 +52,8 @@ func NewConnector(s frame.CmdSender, dispatcher *frame.Dispatcher) *Connector {
 //
 // https://pulsar.incubator.apache.org/docs/latest/project/BinaryProtocol/#Connectionestablishment-ly8l2n
 type Connector struct {
-	S          frame.CmdSender
-	Dispatcher *frame.Dispatcher // used to manage the request/response state
+	s          frame.CmdSender
+	dispatcher *frame.Dispatcher // used to manage the request/response state
 }
 
 // Connect initiates the client's session. After sending,
@@ -48,17 +64,17 @@ type Connector struct {
 //
 // It's required to have completed Connect/Connected before using the client.
 func (c *Connector) Connect(ctx context.Context, authMethod, proxyBrokerURL string) (*api.CommandConnected, error) {
-	resp, cancel, err := c.Dispatcher.RegisterGlobal()
+	resp, cancel, err := c.dispatcher.RegisterGlobal()
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
 
 	// NOTE: The source seems to indicate that the ERROR messages's
-	// RequestID will be -1 (ie UndefRequestID) in the case that it's
+	// RequestID will be -1 (ie undefRequestID) in the case that it's
 	// associated with a CONNECT request.
 	// https://github.com/apache/incubator-pulsar/blob/fdc7b8426d8253c9437777ae51a4639239550f00/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java#L325
-	errResp, cancel, err := c.Dispatcher.RegisterReqID(utils.UndefRequestID)
+	errResp, cancel, err := c.dispatcher.RegisterReqID(undefRequestID)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +83,8 @@ func (c *Connector) Connect(ctx context.Context, authMethod, proxyBrokerURL stri
 	// create and send CONNECT msg
 
 	connect := api.CommandConnect{
-		ClientVersion:   proto.String(utils.ClientVersion),
-		ProtocolVersion: proto.Int32(utils.ProtoVersion),
+		ClientVersion:   proto.String(ClientVersion),
+		ProtocolVersion: proto.Int32(ProtoVersion),
 	}
 	if authMethod != "" {
 		connect.AuthMethodName = proto.String(authMethod)
@@ -82,7 +98,7 @@ func (c *Connector) Connect(ctx context.Context, authMethod, proxyBrokerURL stri
 		Connect: &connect,
 	}
 
-	if err := c.S.SendSimpleCmd(cmd); err != nil {
+	if err := c.s.SendSimpleCmd(cmd); err != nil {
 		return nil, err
 	}
 

--- a/core/conn/connector_test.go
+++ b/core/conn/connector_test.go
@@ -40,7 +40,7 @@ func TestConnector(t *testing.T) {
 
 	go func() {
 		var r response
-		r.success, r.err = c.Connect(ctx, "", "")
+		r.success, r.err = c.Connect(ctx, "", nil, "")
 		resps <- r
 	}()
 
@@ -94,7 +94,7 @@ func TestConnector_Timeout(t *testing.T) {
 
 	go func() {
 		var r response
-		r.success, r.err = c.Connect(ctx, "", "")
+		r.success, r.err = c.Connect(ctx, "", nil, "")
 		resps <- r
 	}()
 
@@ -148,7 +148,7 @@ func TestConnector_Error(t *testing.T) {
 
 	go func() {
 		var r response
-		r.success, r.err = c.Connect(ctx, "", "")
+		r.success, r.err = c.Connect(ctx, "", nil, "")
 		resps <- r
 	}()
 
@@ -208,13 +208,13 @@ func TestConnector_Outstanding(t *testing.T) {
 	defer cancel()
 
 	// perform 1st connect
-	go c.Connect(ctx, "", "")
+	go c.Connect(ctx, "", nil, "")
 
 	time.Sleep(100 * time.Millisecond)
 
 	// Additional attempts to connect while there's
 	// an outstanding one should cause an error
-	if _, err := c.Connect(ctx, "", ""); err == nil {
+	if _, err := c.Connect(ctx, "", nil, ""); err == nil {
 		t.Fatalf("connector.connect() err = %v; expected non-nil because of outstanding request", err)
 	} else {
 		t.Logf("connector.connect() err = %v", err)

--- a/core/conn/connector_test.go
+++ b/core/conn/connector_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/wolfstudy/pulsar-client-go/core/frame"
 	"github.com/wolfstudy/pulsar-client-go/pkg/api"
-	"github.com/wolfstudy/pulsar-client-go/utils"
 )
 
 func TestConnector(t *testing.T) {
@@ -156,7 +155,7 @@ func TestConnector_Error(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	errorMsg := api.CommandError{
-		RequestId: proto.Uint64(utils.UndefRequestID),
+		RequestId: proto.Uint64(undefRequestID),
 		Message:   proto.String("there was an error of sorts"),
 	}
 	f := frame.Frame{
@@ -165,7 +164,7 @@ func TestConnector_Error(t *testing.T) {
 			Error: &errorMsg,
 		},
 	}
-	if err := dispatcher.NotifyReqID(utils.UndefRequestID, f); err != nil {
+	if err := dispatcher.NotifyReqID(undefRequestID, f); err != nil {
 		t.Fatalf("HandleReqID() err = %v; nil expected", err)
 	}
 

--- a/core/conn/mockserver.go
+++ b/core/conn/mockserver.go
@@ -19,13 +19,6 @@ import (
 	"net"
 )
 
-// MockPulsarServer emulates a Pulsar server
-type MockPulsarServer struct {
-	Addr  string
-	Errs  chan error
-	Conns chan *Conn
-}
-
 func NewMockPulsarServer(ctx context.Context) (*MockPulsarServer, error) {
 	l, err := net.ListenTCP("tcp4", &net.TCPAddr{
 		IP:   net.IPv4zero,
@@ -62,14 +55,21 @@ func NewMockPulsarServer(ctx context.Context) (*MockPulsarServer, error) {
 			}()
 
 			mock.Conns <- &Conn{
-				Rc:      c,
-				W:       c,
-				Closedc: make(chan struct{}),
+				rc:      c,
+				w:       c,
+				closedc: make(chan struct{}),
 			}
 		}
 	}()
 
 	return &mock, nil
+}
+
+// MockPulsarServer emulates a Pulsar server
+type MockPulsarServer struct {
+	Addr  string
+	Errs  chan error
+	Conns chan *Conn
 }
 
 

--- a/core/frame/mocksender.go
+++ b/core/frame/mocksender.go
@@ -29,14 +29,14 @@ type CmdSender interface {
 
 // MockSender implements the sender interface
 type MockSender struct {
-	Mu      sync.Mutex // protects following
+	mu      sync.Mutex // protects following
 	Frames  []Frame
-	Closedc chan struct{}
+	closedc chan struct{}
 }
 
 func (m *MockSender) GetFrames() []Frame {
-	m.Mu.Lock()
-	defer m.Mu.Unlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	cp := make([]Frame, len(m.Frames))
 	copy(cp, m.Frames)
@@ -45,8 +45,8 @@ func (m *MockSender) GetFrames() []Frame {
 }
 
 func (m *MockSender) SendSimpleCmd(cmd api.BaseCommand) error {
-	m.Mu.Lock()
-	defer m.Mu.Unlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	m.Frames = append(m.Frames, Frame{
 		BaseCmd: &cmd,
@@ -56,8 +56,8 @@ func (m *MockSender) SendSimpleCmd(cmd api.BaseCommand) error {
 }
 
 func (m *MockSender) SendPayloadCmd(cmd api.BaseCommand, metadata api.MessageMetadata, payload []byte) error {
-	m.Mu.Lock()
-	defer m.Mu.Unlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	m.Frames = append(m.Frames, Frame{
 		BaseCmd:  &cmd,
@@ -69,5 +69,5 @@ func (m *MockSender) SendPayloadCmd(cmd api.BaseCommand, metadata api.MessageMet
 }
 
 func (m *MockSender) Closed() <-chan struct{} {
-	return m.Closedc
+	return m.closedc
 }

--- a/core/manage/client_test.go
+++ b/core/manage/client_test.go
@@ -62,7 +62,7 @@ func TestClient_Int_PubSub(t *testing.T) {
 		t.Logf("PONG received")
 	}
 
-	topic := fmt.Sprintf("persistent://sample/standalone/ns1/test-%s", utils.RandString(32))
+	topic := fmt.Sprintf("persistent://sample/standalone/ns1/test-%s", RandString(32))
 	t.Logf("test topic: %q", topic)
 
 	topicResp, err := c.LookupTopic(ctx, topic, false)
@@ -83,7 +83,7 @@ func TestClient_Int_PubSub(t *testing.T) {
 
 	// create multiple consumers
 	consumers := make([]*sub.Consumer, 32)
-	subName := utils.RandString(16)
+	subName := RandString(16)
 	for i := range consumers {
 		name := fmt.Sprintf("%s-%d", subName, i)
 		consumers[i], err = c.NewExclusiveConsumer(ctx, topic, name, false, make(chan msg.Message, N))
@@ -208,7 +208,7 @@ func TestClient_Int_ServerInitiatedTopicClose(t *testing.T) {
 		t.Logf("PONG received")
 	}
 
-	topicName := fmt.Sprintf("test-%s", utils.RandString(32))
+	topicName := fmt.Sprintf("test-%s", RandString(32))
 	topic := fmt.Sprintf("persistent://sample/standalone/ns1/%s", topicName)
 	t.Logf("topic: %q", topic)
 
@@ -221,13 +221,13 @@ func TestClient_Int_ServerInitiatedTopicClose(t *testing.T) {
 	}
 	t.Log(topicResp.String())
 
-	subscriptionName := utils.RandString(32)
+	subscriptionName := RandString(32)
 	topicConsumer, err := c.NewExclusiveConsumer(ctx, topic, subscriptionName, false, make(chan msg.Message, 1))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	producerName := utils.RandString(32)
+	producerName := RandString(32)
 	topicProducer, err := c.NewProducer(ctx, topic, producerName)
 	if err != nil {
 		t.Fatal(err)
@@ -327,7 +327,7 @@ func TestClient_Int_Unsubscribe(t *testing.T) {
 					t.Logf("PONG received")
 				}
 
-				topic := fmt.Sprintf("persistent://sample/standalone/ns1/test-%s", utils.RandString(32))
+				topic := fmt.Sprintf("persistent://sample/standalone/ns1/test-%s", RandString(32))
 				t.Logf("test topic: %q", topic)
 
 				topicResp, err := c.LookupTopic(ctx, topic, false)
@@ -351,7 +351,7 @@ func TestClient_Int_Unsubscribe(t *testing.T) {
 				}
 				t.Log(topicResp.String())
 
-				topicConsumer, err := c.NewExclusiveConsumer(ctx, topic, utils.RandString(32), false, make(chan msg.Message, 1))
+				topicConsumer, err := c.NewExclusiveConsumer(ctx, topic, RandString(32), false, make(chan msg.Message, 1))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -400,7 +400,7 @@ func TestClient_Int_RedeliverOverflow(t *testing.T) {
 		t.Logf("PONG received")
 	}
 
-	topic := fmt.Sprintf("persistent://sample/standalone/ns1/test-%s", utils.RandString(32))
+	topic := fmt.Sprintf("persistent://sample/standalone/ns1/test-%s", RandString(32))
 	t.Logf("test topic: %q", topic)
 
 	topicResp, err := c.LookupTopic(ctx, topic, false)
@@ -426,7 +426,7 @@ func TestClient_Int_RedeliverOverflow(t *testing.T) {
 	}
 
 	// create single consumer with buffer size 1
-	cs, err := c.NewSharedConsumer(ctx, topic, utils.RandString(16), make(chan msg.Message, 1))
+	cs, err := c.NewSharedConsumer(ctx, topic, RandString(16), make(chan msg.Message, 1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -532,7 +532,7 @@ func TestClient_Int_RedeliverAll(t *testing.T) {
 		t.Logf("PONG received")
 	}
 
-	topic := fmt.Sprintf("persistent://sample/standalone/ns1/test-%s", utils.RandString(32))
+	topic := fmt.Sprintf("persistent://sample/standalone/ns1/test-%s", RandString(32))
 	t.Logf("test topic: %q", topic)
 
 	topicResp, err := c.LookupTopic(ctx, topic, false)
@@ -558,7 +558,7 @@ func TestClient_Int_RedeliverAll(t *testing.T) {
 	}
 
 	// create single consumer with buffer size N
-	cs, err := c.NewExclusiveConsumer(ctx, topic, utils.RandString(16), false, make(chan msg.Message, N))
+	cs, err := c.NewExclusiveConsumer(ctx, topic, RandString(16), false, make(chan msg.Message, N))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/manage/managed_client.go
+++ b/core/manage/managed_client.go
@@ -35,6 +35,8 @@ type ManagedClientConfig struct {
 
 // setDefaults returns a modified config with appropriate zero values set to defaults.
 func (m ManagedClientConfig) setDefaults() ManagedClientConfig {
+	m.ClientConfig = m.ClientConfig.setDefaults()
+
 	if m.PingFrequency <= 0 {
 		m.PingFrequency = 30 * time.Second // default used by Java client
 	}
@@ -186,7 +188,7 @@ func (m *ManagedClient) newClient(ctx context.Context) (*Client, error) {
 	if m.cfg.phyAddr != m.cfg.Addr {
 		proxyBrokerURL = m.cfg.Addr
 	}
-	if m.cfg.TLSConfig != nil {
+	if m.cfg.UseTLS {
 		_, err = client.ConnectTLS(ctx, proxyBrokerURL)
 	} else {
 		_, err = client.Connect(ctx, proxyBrokerURL)

--- a/core/manage/managed_client.go
+++ b/core/manage/managed_client.go
@@ -188,11 +188,7 @@ func (m *ManagedClient) newClient(ctx context.Context) (*Client, error) {
 	if m.cfg.phyAddr != m.cfg.Addr {
 		proxyBrokerURL = m.cfg.Addr
 	}
-	if m.cfg.UseTLS {
-		_, err = client.ConnectTLS(ctx, proxyBrokerURL)
-	} else {
-		_, err = client.Connect(ctx, proxyBrokerURL)
-	}
+	_, err = client.Connect(ctx, proxyBrokerURL)
 
 	if err != nil {
 		_ = client.Close()

--- a/core/manage/managed_client_pool.go
+++ b/core/manage/managed_client_pool.go
@@ -54,7 +54,7 @@ type clientPoolKey struct {
 // Get returns the ManagedClient for the given client configuration.
 // First the cache is checked for an existing client. If one doesn't exist,
 // a new one is created and cached, then returned.
-func (m *ClientPool) Get(cfg ClientConfig) *ManagedClient {
+func (m *ClientPool) Get(cfg ManagedClientConfig) *ManagedClient {
 	key := clientPoolKey{
 		logicalAddr:           strings.TrimPrefix(cfg.Addr, "pulsar://"),
 		dialTimeout:           cfg.DialTimeout,
@@ -107,7 +107,7 @@ const maxTopicLookupRedirects = 8
 // the ManagedClient for the discovered topic information.
 // https://pulsar.incubator.apache.org/docs/latest/project/BinaryProtocol/#Topiclookup-6g0lo
 // incubator-pulsar/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
-func (m *ClientPool) ForTopic(ctx context.Context, cfg ClientConfig, topic string) (*ManagedClient, error) {
+func (m *ClientPool) ForTopic(ctx context.Context, cfg ManagedClientConfig, topic string) (*ManagedClient, error) {
 	// For initial lookup request, authoritative should == false
 	var authoritative bool
 	serviceAddr := cfg.Addr

--- a/core/manage/managed_client_pool.go
+++ b/core/manage/managed_client_pool.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/wolfstudy/pulsar-client-go/core/conn"
 	"github.com/wolfstudy/pulsar-client-go/pkg/api"
 )
 
@@ -55,10 +56,11 @@ type clientPoolKey struct {
 // First the cache is checked for an existing client. If one doesn't exist,
 // a new one is created and cached, then returned.
 func (m *ClientPool) Get(cfg ManagedClientConfig) *ManagedClient {
+	cfg = cfg.setDefaults()
 	key := clientPoolKey{
-		logicalAddr:           strings.TrimPrefix(cfg.Addr, "pulsar://"),
+		logicalAddr:           strings.TrimPrefix(strings.TrimPrefix(cfg.Addr, conn.SchemaPulsar), conn.SchemaPulsarTSL),
 		dialTimeout:           cfg.DialTimeout,
-		tls:                   cfg.TLSConfig != nil,
+		tls:                   cfg.UseTLS,
 		pingFrequency:         cfg.PingFrequency,
 		pingTimeout:           cfg.PingTimeout,
 		connectTimeout:        cfg.ConnectTimeout,
@@ -139,7 +141,7 @@ func (m *ClientPool) ForTopic(ctx context.Context, cfg ManagedClientConfig, topi
 
 		// Update configured address with address
 		// provided in response
-		if cfg.TLSConfig != nil {
+		if cfg.UseTLS {
 			cfg.Addr = lookupResp.GetBrokerServiceUrlTls()
 		} else {
 			cfg.Addr = lookupResp.GetBrokerServiceUrl()

--- a/core/manage/managed_client_pool_test.go
+++ b/core/manage/managed_client_pool_test.go
@@ -32,9 +32,9 @@ func TestManagedClientPool(t *testing.T) {
 	}
 
 	mcp := NewClientPool()
-	mc := mcp.Get(ClientConfig{
+	mc := mcp.Get(ManagedClientConfig{ClientConfig: ClientConfig{
 		Addr: srv.Addr,
-	})
+	}})
 
 	expectedFrames := []api.BaseCommand_Type{
 		api.BaseCommand_CONNECT,
@@ -49,9 +49,9 @@ func TestManagedClientPool(t *testing.T) {
 	}
 
 	// Assert additional call to Get returns same object
-	mc2 := mcp.Get(ClientConfig{
+	mc2 := mcp.Get(ManagedClientConfig{ClientConfig: ClientConfig{
 		Addr: srv.Addr,
-	})
+	}})
 	if mc != mc2 {
 		t.Fatalf("Get() returned %v; expected identical result from first call to Get() %v", mc2, mc)
 	}
@@ -67,9 +67,9 @@ func TestManagedClientPool_Stop(t *testing.T) {
 	}
 
 	mcp := NewClientPool()
-	mc := mcp.Get(ClientConfig{
+	mc := mcp.Get(ManagedClientConfig{ClientConfig: ClientConfig{
 		Addr: srv.Addr,
-	})
+	}})
 
 	expectedFrames := []api.BaseCommand_Type{
 		api.BaseCommand_CONNECT,
@@ -83,9 +83,9 @@ func TestManagedClientPool_Stop(t *testing.T) {
 	// from the pool
 	time.Sleep(200 * time.Millisecond)
 
-	mc2 := mcp.Get(ClientConfig{
+	mc2 := mcp.Get(ManagedClientConfig{ClientConfig: ClientConfig{
 		Addr: srv.Addr,
-	})
+	}})
 	if mc == mc2 {
 		t.Fatal("Get() returned same ManagedClient as previous; expected different object after calling ManagedClient.Stop()")
 	}
@@ -111,14 +111,14 @@ func TestManagedClientPool_ForTopic(t *testing.T) {
 	topic := "test"
 
 	cp := NewClientPool()
-	mc, err := cp.ForTopic(ctx, ClientConfig{
+	mc, err := cp.ForTopic(ctx, ManagedClientConfig{ClientConfig: ClientConfig{
 		Addr: primarySrv.Addr,
-	}, topic)
+	}}, topic)
 	if err != nil {
 		t.Fatalf("ForTopic() err = %v; expected nil", err)
 	}
 
-	if got, expected := mc.cfg.ConnAddr(), primarySrv.Addr; got != expected {
+	if got, expected := mc.cfg.connAddr(), primarySrv.Addr; got != expected {
 		t.Fatalf("ManagedClient address = %q; expected %q", got, expected)
 	} else {
 		t.Logf("ManagedClient address = %q", got)
@@ -139,9 +139,9 @@ func TestManagedClientPool_ForTopic_Failed(t *testing.T) {
 	primarySrv.SetTopicLookupResp(topic, primarySrv.Addr, api.CommandLookupTopicResponse_Failed, false)
 
 	cp := NewClientPool()
-	_, err = cp.ForTopic(ctx, ClientConfig{
+	_, err = cp.ForTopic(ctx, ManagedClientConfig{ClientConfig: ClientConfig{
 		Addr: primarySrv.Addr,
-	}, topic)
+	}}, topic)
 
 	if err == nil {
 		t.Fatalf("ForTopic() err = %v; expected non-nil", err)
@@ -163,15 +163,15 @@ func TestManagedClientPool_ForTopic_Proxy(t *testing.T) {
 	primarySrv.SetTopicLookupResp(topic, brokerURL, api.CommandLookupTopicResponse_Connect, true)
 
 	cp := NewClientPool()
-	mc, err := cp.ForTopic(ctx, ClientConfig{
+	mc, err := cp.ForTopic(ctx, ManagedClientConfig{ClientConfig: ClientConfig{
 		Addr: primarySrv.Addr,
-	}, topic)
+	}}, topic)
 	if err != nil {
 		t.Fatalf("ForTopic() err = %v; expected nil", err)
 	}
 
 	// original broker addr should be used as physical address
-	if got, expected := mc.cfg.ConnAddr(), primarySrv.Addr; got != expected {
+	if got, expected := mc.cfg.connAddr(), primarySrv.Addr; got != expected {
 		t.Fatalf("ManagedClient address = %q; expected %q", got, expected)
 	} else {
 		t.Logf("ManagedClient address = %q", got)
@@ -209,14 +209,14 @@ func TestManagedClientPool_ForTopic_Connect(t *testing.T) {
 
 	cp := NewClientPool()
 
-	mc, err := cp.ForTopic(ctx, ClientConfig{
+	mc, err := cp.ForTopic(ctx, ManagedClientConfig{ClientConfig: ClientConfig{
 		Addr: primarySrv.Addr,
-	}, topic)
+	}}, topic)
 	if err != nil {
 		t.Fatalf("ForTopic() err = %v; expected nil", err)
 	}
 
-	if got, expected := mc.cfg.ConnAddr(), topicSrv.Addr; got != expected {
+	if got, expected := mc.cfg.connAddr(), topicSrv.Addr; got != expected {
 		t.Fatalf("ManagedClient address = %q; expected %q", got, expected)
 	} else {
 		t.Logf("redirected ManagedClient address = %q", got)
@@ -247,14 +247,14 @@ func TestManagedClientPool_ForTopic_Redirect(t *testing.T) {
 
 	cp := NewClientPool()
 
-	mc, err := cp.ForTopic(ctx, ClientConfig{
+	mc, err := cp.ForTopic(ctx, ManagedClientConfig{ClientConfig: ClientConfig{
 		Addr: primarySrv.Addr,
-	}, topic)
+	}}, topic)
 	if err != nil {
 		t.Fatalf("ForTopic() err = %v; expected nil", err)
 	}
 
-	if got, expected := mc.cfg.ConnAddr(), topicSrv.Addr; got != expected {
+	if got, expected := mc.cfg.connAddr(), topicSrv.Addr; got != expected {
 		t.Fatalf("ManagedClient address = %q; expected %q", got, expected)
 	} else {
 		t.Logf("redirected ManagedClient address = %q", got)
@@ -286,9 +286,9 @@ func TestManagedClientPool_ForTopic_RedirectLoop(t *testing.T) {
 
 	cp := NewClientPool()
 
-	_, err = cp.ForTopic(ctx, ClientConfig{
+	_, err = cp.ForTopic(ctx, ManagedClientConfig{ClientConfig: ClientConfig{
 		Addr: primarySrv.Addr,
-	}, topic)
+	}}, topic)
 
 	if err == nil {
 		t.Fatalf("ForTopic() err = %v; expected non-nil", err)

--- a/core/manage/managed_client_test.go
+++ b/core/manage/managed_client_test.go
@@ -31,9 +31,9 @@ func TestManagedClient(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mc := NewManagedClient(ClientConfig{
+	mc := NewManagedClient(ManagedClientConfig{ClientConfig: ClientConfig{
 		Addr: srv.Addr,
-	})
+	}})
 	defer mc.Stop()
 
 	expectedFrames := []api.BaseCommand_Type{
@@ -64,9 +64,9 @@ func TestManagedClient_SrvClosed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mc := NewManagedClient(ClientConfig{
+	mc := NewManagedClient(ManagedClientConfig{ClientConfig: ClientConfig{
 		Addr: srv.Addr,
-	})
+	}})
 	defer mc.Stop()
 
 	// repeatedly close the connection from the server's end;
@@ -108,8 +108,10 @@ func TestManagedClient_PingFailure(t *testing.T) {
 	srv.SetIgnorePings(true)
 
 	// Set client to ping every 1/2 second
-	mc := NewManagedClient(ClientConfig{
-		Addr:          srv.Addr,
+	mc := NewManagedClient(ManagedClientConfig{
+		ClientConfig: ClientConfig{
+			Addr: srv.Addr,
+		},
 		PingFrequency: 500 * time.Millisecond,
 	})
 	defer mc.Stop()
@@ -142,8 +144,10 @@ func TestManagedClient_ConnectFailure(t *testing.T) {
 	// then later enable them
 	srv.SetIgnoreConnects(true)
 
-	mc := NewManagedClient(ClientConfig{
-		Addr:           srv.Addr,
+	mc := NewManagedClient(ManagedClientConfig{
+		ClientConfig: ClientConfig{
+			Addr: srv.Addr,
+		},
 		ConnectTimeout: time.Second, // shorten connect timeout since no CONNECT response is expected
 	})
 	defer mc.Stop()
@@ -180,9 +184,9 @@ func TestManagedClient_Stop(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mc := NewManagedClient(ClientConfig{
+	mc := NewManagedClient(ManagedClientConfig{ClientConfig: ClientConfig{
 		Addr: srv.Addr,
-	})
+	}})
 	defer mc.Stop()
 
 	// wait for the client to connect

--- a/core/manage/managed_consumer_integration_test.go
+++ b/core/manage/managed_consumer_integration_test.go
@@ -35,7 +35,7 @@ func TestManagedConsumer_Int_ReceiveAsync(t *testing.T) {
 		}
 	}()
 
-	topic := fmt.Sprintf("persistent://sample/standalone/ns1/test-%s", utils.RandString(32))
+	topic := fmt.Sprintf("persistent://sample/standalone/ns1/test-%s", RandString(32))
 	cp := NewClientPool()
 	mcCfg := ClientConfig{
 		Addr: utils.PulsarAddr(t),
@@ -45,21 +45,25 @@ func TestManagedConsumer_Int_ReceiveAsync(t *testing.T) {
 	messages := make(chan msg.Message, 16)
 	errs := make(chan error, 1)
 
-	consumerCfg := ConsumerConfig{
-		ClientConfig: mcCfg,
-		Name:         utils.RandString(8),
-		Topic:        topic,
-		QueueSize:    128,
+	consumerCfg := ManagedConsumerConfig{
+		ManagedClientConfig: ManagedClientConfig{
+			ClientConfig: mcCfg,
+		},
+		Name:      RandString(8),
+		Topic:     topic,
+		QueueSize: 128,
 	}
 	mc := NewManagedConsumer(cp, consumerCfg)
 	go func() {
 		errs <- mc.ReceiveAsync(ctx, messages)
 	}()
 
-	producerCfg := ProducerConfig{
-		ClientConfig: mcCfg,
-		Name:         utils.RandString(8),
-		Topic:        topic,
+	producerCfg := ManagedProducerConfig{
+		ManagedClientConfig: ManagedClientConfig{
+			ClientConfig: mcCfg,
+		},
+		Name:  RandString(8),
+		Topic: topic,
 	}
 	mp := NewManagedProducer(cp, producerCfg)
 
@@ -76,7 +80,7 @@ func TestManagedConsumer_Int_ReceiveAsync(t *testing.T) {
 	MORE:
 		for _, msg := range expected {
 			for {
-				if _, err := mp.Send(ctx, []byte(msg),""); err != nil {
+				if _, err := mp.Send(ctx, []byte(msg), ""); err != nil {
 					continue
 				}
 				continue MORE
@@ -133,7 +137,7 @@ func TestManagedConsumer_Int_ReceiveAsync_Multiple(t *testing.T) {
 		}
 	}()
 
-	topic := fmt.Sprintf("persistent://sample/standalone/ns1/test-%s", utils.RandString(32))
+	topic := fmt.Sprintf("persistent://sample/standalone/ns1/test-%s", RandString(32))
 	cp := NewClientPool()
 	mcCfg := ClientConfig{
 		Addr: utils.PulsarAddr(t),
@@ -143,16 +147,18 @@ func TestManagedConsumer_Int_ReceiveAsync_Multiple(t *testing.T) {
 	messages := make(chan msg.Message, 16)
 	errs := make(chan error, 1)
 	consumers := make([]*ManagedConsumer, 8)
-	consumerName := utils.RandString(8)
+	consumerName := RandString(8)
 
 	// Create multiple managed consumers. All will
 	// use the same messages channel.
 	for i := range consumers {
-		consumerCfg := ConsumerConfig{
-			ClientConfig: mcCfg,
-			Name:         consumerName,
-			Topic:        topic,
-			QueueSize:    128,
+		consumerCfg := ManagedConsumerConfig{
+			ManagedClientConfig: ManagedClientConfig{
+				ClientConfig: mcCfg,
+			},
+			Name:      consumerName,
+			Topic:     topic,
+			QueueSize: 128,
 		}
 		consumers[i] = NewManagedConsumer(cp, consumerCfg)
 		go func(mc *ManagedConsumer) {
@@ -160,10 +166,12 @@ func TestManagedConsumer_Int_ReceiveAsync_Multiple(t *testing.T) {
 		}(consumers[i])
 	}
 
-	producerCfg := ProducerConfig{
-		ClientConfig: mcCfg,
-		Name:         utils.RandString(8),
-		Topic:        topic,
+	producerCfg := ManagedProducerConfig{
+		ManagedClientConfig: ManagedClientConfig{
+			ClientConfig: mcCfg,
+		},
+		Name:  RandString(8),
+		Topic: topic,
 	}
 	mp := NewManagedProducer(cp, producerCfg)
 
@@ -180,7 +188,7 @@ func TestManagedConsumer_Int_ReceiveAsync_Multiple(t *testing.T) {
 	MORE:
 		for _, msg := range expected {
 			for {
-				if _, err := mp.Send(ctx, []byte(msg),""); err != nil {
+				if _, err := mp.Send(ctx, []byte(msg), ""); err != nil {
 					continue
 				}
 				continue MORE

--- a/core/manage/managed_consumer_test.go
+++ b/core/manage/managed_consumer_test.go
@@ -36,9 +36,11 @@ func TestManagedConsumer(t *testing.T) {
 	}
 
 	cp := NewClientPool()
-	mc := NewManagedConsumer(cp, ConsumerConfig{
-		ClientConfig: ClientConfig{
-			Addr: srv.Addr,
+	mc := NewManagedConsumer(cp, ManagedConsumerConfig{
+		ManagedClientConfig: ManagedClientConfig{
+			ClientConfig: ClientConfig{
+				Addr: srv.Addr,
+			},
 		},
 		NewConsumerTimeout: time.Second,
 		Topic:              "test-topic",
@@ -113,9 +115,11 @@ func TestManagedConsumer_ReceiveAsync(t *testing.T) {
 	queueSize := 4
 
 	cp := NewClientPool()
-	mc := NewManagedConsumer(cp, ConsumerConfig{
-		ClientConfig: ClientConfig{
-			Addr: srv.Addr,
+	mc := NewManagedConsumer(cp, ManagedConsumerConfig{
+		ManagedClientConfig: ManagedClientConfig{
+			ClientConfig: ClientConfig{
+				Addr: srv.Addr,
+			},
 		},
 		NewConsumerTimeout: time.Second,
 		Topic:              "test-topic",
@@ -236,9 +240,11 @@ func TestManagedConsumer_SrvClosed(t *testing.T) {
 	}
 
 	cp := NewClientPool()
-	NewManagedConsumer(cp, ConsumerConfig{
-		ClientConfig: ClientConfig{
-			Addr: srv.Addr,
+	NewManagedConsumer(cp, ManagedConsumerConfig{
+		ManagedClientConfig: ManagedClientConfig{
+			ClientConfig: ClientConfig{
+				Addr: srv.Addr,
+			},
 		},
 		NewConsumerTimeout: time.Second,
 		Topic:              "test-topic",
@@ -270,9 +276,11 @@ func TestManagedConsumer_ConsumerClosed(t *testing.T) {
 	}
 
 	cp := NewClientPool()
-	NewManagedConsumer(cp, ConsumerConfig{
-		ClientConfig: ClientConfig{
-			Addr: srv.Addr,
+	NewManagedConsumer(cp, ManagedConsumerConfig{
+		ManagedClientConfig: ManagedClientConfig{
+			ClientConfig: ClientConfig{
+				Addr: srv.Addr,
+			},
 		},
 
 		NewConsumerTimeout: time.Second,

--- a/core/manage/managed_producer_test.go
+++ b/core/manage/managed_producer_test.go
@@ -35,9 +35,11 @@ func TestManagedProducer(t *testing.T) {
 	}
 
 	cp := NewClientPool()
-	mp := NewManagedProducer(cp, ProducerConfig{
-		ClientConfig: ClientConfig{
-			Addr: srv.Addr,
+	mp := NewManagedProducer(cp, ManagedProducerConfig{
+		ManagedClientConfig: ManagedClientConfig{
+			ClientConfig: ClientConfig{
+				Addr: srv.Addr,
+			},
 		},
 		NewProducerTimeout: time.Second,
 		Topic:              "test-topic",
@@ -53,7 +55,7 @@ func TestManagedProducer(t *testing.T) {
 	}
 
 	payload := []byte("hi")
-	if _, err = mp.Send(ctx, payload,""); err != nil {
+	if _, err = mp.Send(ctx, payload, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -91,9 +93,11 @@ func TestManagedProducer_Redirect(t *testing.T) {
 	primarySrv.SetTopicLookupResp(topic, topicSrv.Addr, api.CommandLookupTopicResponse_Connect, false)
 
 	cp := NewClientPool()
-	mp := NewManagedProducer(cp, ProducerConfig{
-		ClientConfig: ClientConfig{
-			Addr: primarySrv.Addr,
+	mp := NewManagedProducer(cp, ManagedProducerConfig{
+		ManagedClientConfig: ManagedClientConfig{
+			ClientConfig: ClientConfig{
+				Addr: primarySrv.Addr,
+			},
 		},
 		NewProducerTimeout: time.Second,
 		Topic:              topic,
@@ -116,7 +120,7 @@ func TestManagedProducer_Redirect(t *testing.T) {
 	}
 
 	payload := []byte("hi")
-	if _, err = mp.Send(ctx, payload,""); err != nil {
+	if _, err = mp.Send(ctx, payload, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -147,9 +151,11 @@ func TestManagedProducer_SrvClosed(t *testing.T) {
 	}
 
 	cp := NewClientPool()
-	mp := NewManagedProducer(cp, ProducerConfig{
-		ClientConfig: ClientConfig{
-			Addr: srv.Addr,
+	mp := NewManagedProducer(cp, ManagedProducerConfig{
+		ManagedClientConfig: ManagedClientConfig{
+			ClientConfig: ClientConfig{
+				Addr: srv.Addr,
+			},
 		},
 		NewProducerTimeout: time.Second,
 		Topic:              "test-topic",
@@ -170,7 +176,7 @@ func TestManagedProducer_SrvClosed(t *testing.T) {
 	}
 
 	payload := []byte("hi")
-	if _, err = mp.Send(ctx, payload,""); err != nil {
+	if _, err = mp.Send(ctx, payload, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -198,9 +204,11 @@ func TestManagedProducer_ProducerClosed(t *testing.T) {
 	}
 
 	cp := NewClientPool()
-	mp := NewManagedProducer(cp, ProducerConfig{
-		ClientConfig: ClientConfig{
-			Addr: srv.Addr,
+	mp := NewManagedProducer(cp, ManagedProducerConfig{
+		ManagedClientConfig: ManagedClientConfig{
+			ClientConfig: ClientConfig{
+				Addr: srv.Addr,
+			},
 		},
 		NewProducerTimeout: time.Second,
 		Topic:              "test-topic",
@@ -257,7 +265,7 @@ func TestManagedProducer_ProducerClosed(t *testing.T) {
 	}
 
 	payload := []byte("hi")
-	if _, err = mp.Send(ctx, payload,""); err != nil {
+	if _, err = mp.Send(ctx, payload, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/core/manage/pubsub_test.go
+++ b/core/manage/pubsub_test.go
@@ -37,7 +37,7 @@ func TestPubsub_Subscribe_Success(t *testing.T) {
 	tp := NewPubsub(&ms, dispatcher, subs, reqID)
 	// manually set consumerID to verify that it's correctly
 	// being set on Consumer
-	tp.ConsumerID = &msg.MonotonicID{ID: consID}
+	tp.consumerID = &msg.MonotonicID{ID: consID}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -84,7 +84,7 @@ func TestPubsub_Subscribe_Success(t *testing.T) {
 		t.Fatalf("got Consumer.consumerID = %d; expected %d", got.ConsumerID, consID)
 	}
 
-	if _, ok := subs.Consumers[got.ConsumerID]; !ok {
+	if _, ok := subs.consumers[got.ConsumerID]; !ok {
 		t.Fatalf("subscriptions.consumers[%d] is absent; expected consumer", got.ConsumerID)
 	}
 }
@@ -138,7 +138,7 @@ func TestPubsub_Subscribe_Error(t *testing.T) {
 	}
 	t.Logf("subscribe() err = %v", r.err)
 
-	if got, expected := len(subs.Consumers), 0; got != expected {
+	if got, expected := len(subs.consumers), 0; got != expected {
 		t.Fatalf("subscriptions.consumers has %d elements; expected %d", got, expected)
 	}
 }
@@ -154,7 +154,7 @@ func TestPubsub_Producer_Success(t *testing.T) {
 	tp := NewPubsub(&ms, dispatcher, subs, reqID)
 	// manually set producerID to verify that it's correctly
 	// being set on Producer
-	tp.ProducerID = &msg.MonotonicID{ID: prodID}
+	tp.producerID = &msg.MonotonicID{ID: prodID}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -206,7 +206,7 @@ func TestPubsub_Producer_Success(t *testing.T) {
 		t.Fatalf("got Producer.producerName = %q; expected %q", got.ProducerName, prodName)
 	}
 
-	if _, ok := subs.Producers[got.ProducerID]; !ok {
+	if _, ok := subs.producers[got.ProducerID]; !ok {
 		t.Fatalf("subscriptions.producers[%d] is absent; expected producer", got.ProducerID)
 	}
 }
@@ -222,7 +222,7 @@ func TestPubsub_Producer_Error(t *testing.T) {
 	tp := NewPubsub(&ms, dispatcher, subs, reqID)
 	// manually set producerID to verify that it's correctly
 	// being set on Producer
-	tp.ProducerID = &msg.MonotonicID{ID: prodID}
+	tp.producerID = &msg.MonotonicID{ID: prodID}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -263,7 +263,7 @@ func TestPubsub_Producer_Error(t *testing.T) {
 	}
 	t.Logf("producer() err = %v", r.err)
 
-	if got, expected := len(subs.Producers), 0; got != expected {
+	if got, expected := len(subs.producers), 0; got != expected {
 		t.Fatalf("subscriptions.producers has %d elements; expected %d", got, expected)
 	}
 }

--- a/core/manage/util_test.go
+++ b/core/manage/util_test.go
@@ -1,0 +1,25 @@
+package manage
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var (
+	randStringChars = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	randStringMu    = new(sync.Mutex) //protects randStringRand, which isn't threadsafe
+	randStringRand  = rand.New(rand.NewSource(time.Now().UnixNano()))
+)
+
+func RandString(n int) string {
+	b := make([]rune, n)
+	l := len(randStringChars)
+	randStringMu.Lock()
+	for i := range b {
+		b[i] = randStringChars[randStringRand.Intn(l)]
+	}
+	randStringMu.Unlock()
+	return string(b)
+}
+

--- a/core/srv/discoverer.go
+++ b/core/srv/discoverer.go
@@ -25,9 +25,9 @@ import (
 // NewDiscoverer returns a ready-to-use discoverer
 func NewDiscoverer(s frame.CmdSender, dispatcher *frame.Dispatcher, reqID *msg.MonotonicID) *Discoverer {
 	return &Discoverer{
-		S:          s,
-		ReqID:      reqID,
-		Dispatcher: dispatcher,
+		s:          s,
+		reqID:      reqID,
+		dispatcher: dispatcher,
 	}
 }
 
@@ -35,9 +35,9 @@ func NewDiscoverer(s frame.CmdSender, dispatcher *frame.Dispatcher, reqID *msg.M
 //
 // https://pulsar.incubator.apache.org/docs/latest/project/BinaryProtocol/#Servicediscovery-40v5m
 type Discoverer struct {
-	S          frame.CmdSender
-	ReqID      *msg.MonotonicID
-	Dispatcher *frame.Dispatcher
+	s          frame.CmdSender
+	reqID      *msg.MonotonicID
+	dispatcher *frame.Dispatcher
 }
 
 // PartitionedMetadata performs a PARTITIONED_METADATA request for the given
@@ -46,7 +46,7 @@ type Discoverer struct {
 //
 // https://pulsar.incubator.apache.org/docs/latest/project/BinaryProtocol/#Partitionedtopicsdiscovery-g14a9h
 func (d *Discoverer) PartitionedMetadata(ctx context.Context, topic string) (*api.CommandPartitionedTopicMetadataResponse, error) {
-	requestID := d.ReqID.Next()
+	requestID := d.reqID.Next()
 	cmd := api.BaseCommand{
 		Type: api.BaseCommand_PARTITIONED_METADATA.Enum(),
 		PartitionMetadata: &api.CommandPartitionedTopicMetadata{
@@ -55,13 +55,13 @@ func (d *Discoverer) PartitionedMetadata(ctx context.Context, topic string) (*ap
 		},
 	}
 
-	resp, cancel, err := d.Dispatcher.RegisterReqID(*requestID)
+	resp, cancel, err := d.dispatcher.RegisterReqID(*requestID)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
 
-	if err := d.S.SendSimpleCmd(cmd); err != nil {
+	if err := d.s.SendSimpleCmd(cmd); err != nil {
 		return nil, err
 	}
 
@@ -82,7 +82,7 @@ func (d *Discoverer) PartitionedMetadata(ctx context.Context, topic string) (*ap
 //
 // https://pulsar.incubator.apache.org/docs/latest/project/BinaryProtocol/#Topiclookup-dk72wp
 func (d *Discoverer) LookupTopic(ctx context.Context, topic string, authoritative bool) (*api.CommandLookupTopicResponse, error) {
-	requestID := d.ReqID.Next()
+	requestID := d.reqID.Next()
 
 	cmd := api.BaseCommand{
 		Type: api.BaseCommand_LOOKUP.Enum(),
@@ -93,13 +93,13 @@ func (d *Discoverer) LookupTopic(ctx context.Context, topic string, authoritativ
 		},
 	}
 
-	resp, cancel, err := d.Dispatcher.RegisterReqID(*requestID)
+	resp, cancel, err := d.dispatcher.RegisterReqID(*requestID)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
 
-	if err := d.S.SendSimpleCmd(cmd); err != nil {
+	if err := d.s.SendSimpleCmd(cmd); err != nil {
 		return nil, err
 	}
 

--- a/core/srv/pinger.go
+++ b/core/srv/pinger.go
@@ -23,8 +23,8 @@ import (
 // NewPinger returns a ready-to-use pinger.
 func NewPinger(s frame.CmdSender, dispatcher *frame.Dispatcher) *Pinger {
 	return &Pinger{
-		S:          s,
-		Dispatcher: dispatcher,
+		s:          s,
+		dispatcher: dispatcher,
 	}
 }
 
@@ -36,15 +36,15 @@ func NewPinger(s frame.CmdSender, dispatcher *frame.Dispatcher) *Pinger {
 //
 // https://pulsar.incubator.apache.org/docs/latest/project/BinaryProtocol/#KeepAlive-53utwq
 type Pinger struct {
-	S          frame.CmdSender
-	Dispatcher *frame.Dispatcher // used to manage the request/response state
+	s          frame.CmdSender
+	dispatcher *frame.Dispatcher // used to manage the request/response state
 }
 
 // Ping sends a PING message to the Pulsar server, then
 // waits for either a PONG response or the context to
 // timeout.
 func (p *Pinger) Ping(ctx context.Context) error {
-	resp, cancel, err := p.Dispatcher.RegisterGlobal()
+	resp, cancel, err := p.dispatcher.RegisterGlobal()
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func (p *Pinger) Ping(ctx context.Context) error {
 		Ping: &api.CommandPing{},
 	}
 
-	if err := p.S.SendSimpleCmd(cmd); err != nil {
+	if err := p.s.SendSimpleCmd(cmd); err != nil {
 		return err
 	}
 
@@ -80,5 +80,5 @@ func (p *Pinger) HandlePing(msgType api.BaseCommand_Type, msg *api.CommandPing) 
 		Pong: &api.CommandPong{},
 	}
 
-	return p.S.SendSimpleCmd(cmd)
+	return p.s.SendSimpleCmd(cmd)
 }

--- a/core/sub/consumer_test.go
+++ b/core/sub/consumer_test.go
@@ -178,7 +178,7 @@ func TestConsumer_handleMessage_fullQueue(t *testing.T) {
 			t.Fatalf("handleMessage() err = %v; expected nil for msg number %d and queueSize %d", err, i+1, queueSize)
 		}
 
-		if got, expected := len(c.Overflow), 0; got != expected {
+		if got, expected := len(c.overflow), 0; got != expected {
 			t.Fatalf("len(consumer overflow buffer) = %d; expected %d", got, expected)
 		}
 	}
@@ -191,7 +191,7 @@ func TestConsumer_handleMessage_fullQueue(t *testing.T) {
 	}
 	t.Logf("handleMessage() err (expected) = %q for msg number %d and queueSize %d", err, queueSize+1, queueSize)
 
-	if got, expected := len(c.Overflow), 1; got != expected {
+	if got, expected := len(c.overflow), 1; got != expected {
 		t.Fatalf("len(consumer overflow buffer) = %d; expected %d", got, expected)
 	}
 
@@ -302,7 +302,7 @@ func TestConsumer_RedeliverOverflow(t *testing.T) {
 		entryID := uint64(i)
 		// the msg.MessageIdData must be unique for each msg.Message,
 		// otherwise the consumer will consider them duplicates
-		// and not store them in Overflow
+		// and not store them in overflow
 		f := frame.Frame{
 			BaseCmd: &api.BaseCommand{
 				Type: api.BaseCommand_MESSAGE.Enum(),

--- a/examples/consumer/consumer.go
+++ b/examples/consumer/consumer.go
@@ -33,9 +33,11 @@ var clientPool = manage.NewClientPool()
 func main() {
 	ctx := context.Background()
 
-	consumerConf := manage.ConsumerConfig{
-		ClientConfig: manage.ClientConfig{
-			Addr: "localhost:6650",
+	consumerConf := manage.ManagedConsumerConfig{
+		ManagedClientConfig: manage.ManagedClientConfig{
+			ClientConfig: manage.ClientConfig{
+				Addr: "localhost:6650",
+			},
 		},
 
 		Topic:   "multi-topic-10",
@@ -46,14 +48,14 @@ func main() {
 		QueueSize:        5,
 	}
 	//mp := manage.NewManagedConsumer(clientPool, consumerConf)
-	mp, err := manage.NewPartitionManagedConsumer(clientPool, consumerConf)
+	mp, err := manage.NewManagedPartitionConsumer(clientPool, consumerConf)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	//mp2 := manage.NewManagedConsumer(clientPool, consumerConf)
 
-	mp2, err := manage.NewPartitionManagedConsumer(clientPool, consumerConf)
+	mp2, err := manage.NewManagedPartitionConsumer(clientPool, consumerConf)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/producer/producer.go
+++ b/examples/producer/producer.go
@@ -33,9 +33,11 @@ var clientPool = manage.NewClientPool()
 
 func main() {
 	ctx := context.Background()
-	producerConf := manage.ProducerConfig{
-		ClientConfig: manage.ClientConfig{
-			Addr: "localhost:6650",
+	producerConf := manage.ManagedProducerConfig{
+		ManagedClientConfig: manage.ManagedClientConfig{
+			ClientConfig: manage.ClientConfig{
+				Addr: "localhost:6650",
+			},
 		},
 
 		Topic: "multi-topic-10",

--- a/utils/util.go
+++ b/utils/util.go
@@ -15,55 +15,12 @@ package utils
 
 import (
 	"flag"
-	"math/rand"
-	"sync"
 	"testing"
-	"time"
-
-	"github.com/wolfstudy/pulsar-client-go/pkg/api"
 )
 
 // ################
 // helper functions
 // ################
-
-var (
-	randStringChars = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-	randStringMu    = new(sync.Mutex) //protects randStringRand, which isn't threadsafe
-	randStringRand  = rand.New(rand.NewSource(time.Now().UnixNano()))
-)
-
-// authMethodTLS is the name of the TLS authentication
-// method, used in the CONNECT message.
-const AuthMethodTLS = "tls"
-
-const (
-	// ProtoVersion is the Pulsar protocol version
-	// used by this client.
-	ProtoVersion = int32(api.ProtocolVersion_v12)
-
-	// ClientVersion is an opaque string sent
-	// by the client to the server on connect, eg:
-	// "Pulsar-Client-Java-v1.15.2"
-	ClientVersion = "pulsar-client-go"
-
-	// NndefRequestID defines a RequestID of -1.
-	//
-	// Usage example:
-	// https://github.com/apache/incubator-pulsar/blob/fdc7b8426d8253c9437777ae51a4639239550f00/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java#L325
-	UndefRequestID = 1<<64 - 1
-)
-
-func RandString(n int) string {
-	b := make([]rune, n)
-	l := len(randStringChars)
-	randStringMu.Lock()
-	for i := range b {
-		b[i] = randStringChars[randStringRand.Intn(l)]
-	}
-	randStringMu.Unlock()
-	return string(b)
-}
 
 // pulsarAddr, if provided, is the Pulsar server to use for integration
 // tests (most likely Pulsar standalone running on localhost).


### PR DESCRIPTION
### Motivation

I've tried to connect to Pulsar with token authentication, but client does not support this auth mode.

### Modifications

1. I've split TLSConfig and tls auth mode. TLSConfig is now used to set up connection.
2. I added Authentication interface and some basic implementations.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests.
